### PR TITLE
Add futher dependencies for ffmpeg on Ubuntu

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,8 @@ InstallDependencies() {
         libjack-jackd2-dev libxcomposite-dev x11proto-composite-dev \
         libx264-dev libgl1-mesa-dev libglu1-mesa-dev libasound2-dev \
         libpulse-dev libx11-dev libxext-dev libxfixes-dev \
-        libxi-dev qt5-default qttools5-dev qt5-qmake qtbase5-dev
+        libxi-dev qt5-default qttools5-dev qt5-qmake qtbase5-dev \
+        libavdevice57 libavfilter6 libavresample3 libpostproc5
 }
 
 # TODO Detect running system


### PR DESCRIPTION
I could not get ffmpeg to work without installing "libavdevice57 libavfilter6 libavresample3 libpostproc54", so I have added those to the dependency installation part in the script.