### PR TITLE
Fix missing dependencies

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -88,6 +88,7 @@ InstallNvCodecIncludes() {
     git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
     cd nv-codec-headers
     make
+    sudo make install
     cp -a include/ffnvcodec "$inc_dir"
 }
 

--- a/build.sh
+++ b/build.sh
@@ -83,10 +83,11 @@ InstallNvidiaSDK() {
 }
 
 InstallNvCodecIncludes() {
-    echo "Installing Nv codec headers from https://github.com/FFmpeg/nv-codec-headers"
+    echo "Installing Nv codec headers from VideoLAN"
     cd "$source_dir"
-    git clone https://github.com/FFmpeg/nv-codec-headers
+    git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
     cd nv-codec-headers
+    make
     cp -a include/ffnvcodec "$inc_dir"
 }
 

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ InstallDependencies() {
         libjack-jackd2-dev libxcomposite-dev x11proto-composite-dev \
         libx264-dev libgl1-mesa-dev libglu1-mesa-dev libasound2-dev \
         libpulse-dev libx11-dev libxext-dev libxfixes-dev \
-        libxi-dev qt5-default qttools5-dev qt5-qmake qtbase5-dev
+        libxi-dev qt5-default qttools5-dev qt5-qmake qtbase5-dev libmbedtls-dev
 }
 
 # TODO Detect running system


### PR DESCRIPTION
This was tested on Ubuntu 18.10.

It fixes #22 and also the missing libmbedtls-dev.